### PR TITLE
Pass entire int array to picosat_add_lits once per clause, in AddClauses()

### DIFF
--- a/pigosat.go
+++ b/pigosat.go
@@ -205,16 +205,20 @@ func (p *Pigosat) AddClauses(clauses [][]int32) {
 	}
 	p.lock.Lock()
 	defer p.lock.Unlock()
-
 	var count int
 	for _, clause := range clauses {
 		count = len(clause)
 		if count == 0 {
 			continue
 		}
+		// picosat requires that a clause ends in a 0, otherwise it will
+		// result in a buffer overflow.
+		// If the provided clause does not end in 0, then
+		// we need to append it ourselves.
 		if clause[count-1] != 0 {
 			clause = append(clause, 0)
 		}
+		// int picosat_add_lits (PicoSAT *, int * lits);
 		C.picosat_add_lits(p.p, (*C.int)(&clause[0]))
 	}
 }

--- a/pigosat.go
+++ b/pigosat.go
@@ -205,23 +205,17 @@ func (p *Pigosat) AddClauses(clauses [][]int32) {
 	}
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	var had0 bool
+
+	var count int
 	for _, clause := range clauses {
-		if len(clause) == 0 {
+		count = len(clause)
+		if count == 0 {
 			continue
 		}
-		had0 = false
-		for _, lit := range clause {
-			// int picosat_add (PicoSAT *, int lit);
-			C.picosat_add(p.p, C.int(lit))
-			if lit == 0 {
-				had0 = true
-				break
-			}
+		if clause[count-1] != 0 {
+			clause = append(clause, 0)
 		}
-		if !had0 {
-			C.picosat_add(p.p, 0)
-		}
+		C.picosat_add_lits(p.p, (*C.int)(&clause[0]))
 	}
 }
 


### PR DESCRIPTION
This improves performance when passing a bunch of clauses, by reducing the number of times we need to call into C. Instead of once per literal, it is once per clause. 