### PR TITLE
Types

### DIFF
--- a/optimize.go
+++ b/optimize.go
@@ -21,12 +21,12 @@ type Minimizer interface {
 	// any set of constraints it likes as long as there is a unique integer K
 	// such that k < K implies IsFeasible(k) returns status Unsatisfiable and
 	// k >= K implies IsFeasible(k) returns status Satisfiable.
-	IsFeasible(k int) (status int, solution []bool)
+	IsFeasible(k int) (status Status, solution Solution)
 
 	// RecordSolution allows types implementing this interface to store
 	// solutions for after minimization has finished. Must be safe for parallel
 	// use.
-	RecordSolution(k, status int, solution []bool)
+	RecordSolution(k int, status Status, solution Solution)
 }
 
 // Minimize finds the value min that minimizes Minimizer m. If the value can be

--- a/optimize_test.go
+++ b/optimize_test.go
@@ -19,8 +19,9 @@ type parameters struct {
 }
 
 type arguments struct {
-	k, status int
-	solution  []bool
+	k        int
+	status   Status
+	solution Solution
 }
 
 type minimizer struct {
@@ -40,7 +41,7 @@ func (m *minimizer) LowerBound() int { return m.params.lower }
 
 func (m *minimizer) UpperBound() int { return m.params.upper }
 
-func (m *minimizer) IsFeasible(k int) (status int, solution []bool) {
+func (m *minimizer) IsFeasible(k int) (status Status, solution Solution) {
 	if k < from {
 		m.t.Errorf("k too low: %d", k)
 	}
@@ -55,7 +56,7 @@ func (m *minimizer) IsFeasible(k int) (status int, solution []bool) {
 	return
 }
 
-func (m *minimizer) RecordSolution(k, status int, solution []bool) {
+func (m *minimizer) RecordSolution(k int, status Status, solution Solution) {
 	m.args <- arguments{k, status, solution}
 }
 

--- a/pigosat.go
+++ b/pigosat.go
@@ -34,18 +34,21 @@ const PicosatVersion = "960"
 // the variable must be true; negative indicates it must be false. Variables
 // should be indexed from one. The zero literal indicates the end of a clause.
 type Literal int32
+
 // Clauses are slices of literals ORed together. An optional zero ends a clause,
 // even in the middle of a slice; [1, 0, 2] is the same as [1, 0] is the same as
 // [1].
 type Clause []Literal
+
 // Formulas are slices of Clauses ANDed together.
 type Formula []Clause
+
 // Solutions are indexed by variable and return the truth value of the given
 // variable. The zeroth element has no meaning and is always false.
 type Solution []bool
+
 // Statuses are returned by Pigosat.Solve to indicate success or failure.
 type Status int
-
 
 // Return values for Pigosat.Solve's status.
 const (
@@ -208,12 +211,12 @@ func (p *Pigosat) Seconds() time.Duration {
 }
 
 // AddClauses adds a slice of clauses, each of which are a slice of literals.
-// Each clause is a list of integers called literals. The absolute value of the literal i is
-// the subscript for some variable x_i. If the literal is positive, x_i must end
-// up being true when the formula is solved. If the literal is negative, it must
-// end up false. Each clause ORs the literals together. All the clauses are
-// ANDed together. An optional zero ends a clause, even in the middle of a
-// slice; [1, 0, 2] is the same as [1, 0] is the same as [1].
+// Each clause is a list of integers called literals. The absolute value of the
+// literal i is the subscript for some variable x_i. If the literal is positive,
+// x_i must end up being true when the formula is solved. If the literal is
+// negative, it must end up false. Each clause ORs the literals together. All
+// the clauses are ANDed together. An optional zero ends a clause, even in the
+// middle of a slice; [1, 0, 2] is the same as [1, 0] is the same as [1].
 func (p *Pigosat) AddClauses(clauses Formula) {
 	defer p.ready(false)()
 	var count int


### PR DESCRIPTION
Fixes #8

By using Pigosat specific types — `Literal` instead of `int32`, `Formula` instead of `[][]int32` — we address two problems. First, I'm hoping the API is easier to understand for a beginner. Second, it makes maintenance easier: e.g., we can change the literal type from `int32` to `int64` just by changing the `type Literal int32` line. Eventually we could even add methods like

```go
func (lit Literal) Bool() bool {
    if lit > 0 {
        return true
    }
    return false
}
```

(I'm not adding this method now because I don't think it's entirely necessary at this point.)

@justinfx, wondering what you think about this. I'd like to get the API right, add a few more features, bump to version 1, then set this project aside.