### PR TITLE
Add Write clausal core / traces and support io.Writer interface

### DIFF
--- a/pigosat.go
+++ b/pigosat.go
@@ -381,7 +381,7 @@ func cFileWriterWrapper(w io.Writer, writeFn func(*C.FILE) error) (err error) {
 	if err != nil {
 		return err
 	}
-	// To avoid double closing wp, close it explicitly at each errror branch.
+	// To avoid double closing wp, close it explicitly at each error branch.
 	defer func() {
 		if e := rp.Close(); e != nil { // Don't hide prior errors.
 			err = e

--- a/pigosat.go
+++ b/pigosat.go
@@ -332,9 +332,7 @@ func (p *Pigosat) BlockSolution(solution Solution) error {
 // Requires that Pigosat was created with EnableTrace == true.
 func (p *Pigosat) WriteClausalCore(f io.Writer) error {
 	defer p.ready(true)()
-
-	res := Status(C.picosat_res(p.p))
-	if res != Unsatisfiable {
+	if Status(C.picosat_res(p.p)) != Unsatisfiable {
 		return errors.New("expected to be in Unsatisfiable state")
 	}
 
@@ -350,9 +348,7 @@ func (p *Pigosat) WriteClausalCore(f io.Writer) error {
 // Requires that Pigosat was created with EnableTrace == true.
 func (p *Pigosat) WriteCompactTrace(f io.Writer) error {
 	defer p.ready(true)()
-
-	res := Status(C.picosat_res(p.p))
-	if res != Unsatisfiable {
+	if Status(C.picosat_res(p.p)) != Unsatisfiable {
 		return errors.New("expected to be in Unsatisfiable state")
 	}
 
@@ -368,9 +364,7 @@ func (p *Pigosat) WriteCompactTrace(f io.Writer) error {
 // Requires that Pigosat was created with EnableTrace == true.
 func (p *Pigosat) WriteExtendedTrace(f io.Writer) error {
 	defer p.ready(true)()
-
-	res := Status(C.picosat_res(p.p))
-	if res != Unsatisfiable {
+	if Status(C.picosat_res(p.p)) != Unsatisfiable {
 		return errors.New("expected to be in Unsatisfiable state")
 	}
 

--- a/pigosat.go
+++ b/pigosat.go
@@ -328,9 +328,7 @@ func (p *Pigosat) BlockSolution(solution Solution) error {
 }
 
 // WriteClausalCore writes in DIMACS format the clauses that were used in
-// deriving the empty clause.
-//
-// Requires that Pigosat was created with EnableTrace == true.
+// deriving the empty clause. Requires that p was created with EnableTrace.
 func (p *Pigosat) WriteClausalCore(f io.Writer) error {
 	defer p.ready(true)()
 	if Status(C.picosat_res(p.p)) != Unsatisfiable {
@@ -344,9 +342,8 @@ func (p *Pigosat) WriteClausalCore(f io.Writer) error {
 	})
 }
 
-// WriteCompactTrace writes a compact proof trace in TraceCheck format.
-//
-// Requires that Pigosat was created with EnableTrace == true.
+// WriteCompactTrace writes a compact proof trace in TraceCheck format. Requires
+// that p was created with EnableTrace.
 func (p *Pigosat) WriteCompactTrace(f io.Writer) error {
 	defer p.ready(true)()
 	if Status(C.picosat_res(p.p)) != Unsatisfiable {
@@ -361,8 +358,7 @@ func (p *Pigosat) WriteCompactTrace(f io.Writer) error {
 }
 
 // WriteExtendedTrace writes an extended proof trace in TraceCheck format.
-//
-// Requires that Pigosat was created with EnableTrace == true.
+// Requires that p was created with EnableTrace.
 func (p *Pigosat) WriteExtendedTrace(f io.Writer) error {
 	defer p.ready(true)()
 	if Status(C.picosat_res(p.p)) != Unsatisfiable {

--- a/pigosat.go
+++ b/pigosat.go
@@ -248,7 +248,6 @@ func (p *Pigosat) AddClauses(clauses Formula) {
 }
 
 // Print appends the CNF in DIMACS format to the given file.
-// func (p *Pigosat) Print(file *os.File) error {
 func (p *Pigosat) Print(w io.Writer) error {
 	defer p.ready(true)()
 	return cFileWriterWrapper(w, func(cfile *C.FILE) error {

--- a/pigosat.go
+++ b/pigosat.go
@@ -101,15 +101,10 @@ type Options struct {
 	 */
 	MeasureAllCalls bool
 
-	// If you ever want to extract cores or proof traces with the current
-	// instance of Pigosat, then set this option true.
-	//
-	// NOTE, trace generation code is not necessarily included, e.g. if you
-	// build Pigosat with the 'no_trace' build tag, you do not get any results
-	// by trying to generate traces.
-	//
-	// After calling NewPigosat, if Pigosat was build with the 'no_trace' build
-	// tag, it will return an error.
+	// If you want to extract cores or proof traces using WriteClausalCore,
+	// WriteCompactTrace, WriteExtendedTrace with the current instance of
+	// Pigosat, then set this option true. This option may increase memory
+	// usage.
 	EnableTrace bool
 }
 

--- a/pigosat.go
+++ b/pigosat.go
@@ -405,6 +405,7 @@ func cFileWriterWrapper(w io.Writer, writeFn func(*C.FILE) error) (err error) {
 	if err != nil {
 		return err
 	}
+	closeCloser(wp)
 	_, err = io.Copy(w, rp)
 	return err
 }

--- a/pigosat.go
+++ b/pigosat.go
@@ -247,7 +247,7 @@ func (p *Pigosat) AddClauses(clauses Formula) {
 	}
 }
 
-// Print appends the CNF in DIMACS format to the given file.
+// Print appends the formula in DIMACS format to the given io.Writer.
 func (p *Pigosat) Print(w io.Writer) error {
 	defer p.ready(true)()
 	return cFileWriterWrapper(w, func(cfile *C.FILE) error {
@@ -325,8 +325,8 @@ func (p *Pigosat) BlockSolution(solution Solution) error {
 	return nil
 }
 
-// Write the clauses that were used in deriving the empty clause to a file
-// in DIMACS format.
+// WriteClausalCore writes in DIMACS format the clauses that were used in
+// deriving the empty clause.
 //
 // Requires that Pigosat was created with EnableTrace == true.
 func (p *Pigosat) WriteClausalCore(f io.Writer) error {
@@ -342,7 +342,7 @@ func (p *Pigosat) WriteClausalCore(f io.Writer) error {
 	})
 }
 
-// Write a compact proof trace in TraceCheck format to a file.
+// WriteCompactTrace writes a compact proof trace in TraceCheck format.
 //
 // Requires that Pigosat was created with EnableTrace == true.
 func (p *Pigosat) WriteCompactTrace(f io.Writer) error {
@@ -358,7 +358,7 @@ func (p *Pigosat) WriteCompactTrace(f io.Writer) error {
 	})
 }
 
-// Write an extended proof trace in TraceCheck format to a file.
+// WriteExtendedTrace writes an extended proof trace in TraceCheck format.
 //
 // Requires that Pigosat was created with EnableTrace == true.
 func (p *Pigosat) WriteExtendedTrace(f io.Writer) error {

--- a/pigosat.go
+++ b/pigosat.go
@@ -14,7 +14,6 @@ package pigosat
 // #include "picosat.h" /* REMEMBER TO UPDATE PicosatVersion BELOW! */
 import "C"
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -332,7 +331,7 @@ func (p *Pigosat) BlockSolution(solution Solution) error {
 func (p *Pigosat) WriteClausalCore(f io.Writer) error {
 	defer p.ready(true)()
 	if Status(C.picosat_res(p.p)) != Unsatisfiable {
-		return errors.New("expected to be in Unsatisfiable state")
+		return fmt.Errorf("expected to be in Unsatisfiable state")
 	}
 
 	return cFileWriterWrapper(f, func(cfile *C.FILE) error {
@@ -348,7 +347,7 @@ func (p *Pigosat) WriteClausalCore(f io.Writer) error {
 func (p *Pigosat) WriteCompactTrace(f io.Writer) error {
 	defer p.ready(true)()
 	if Status(C.picosat_res(p.p)) != Unsatisfiable {
-		return errors.New("expected to be in Unsatisfiable state")
+		return fmt.Errorf("expected to be in Unsatisfiable state")
 	}
 
 	return cFileWriterWrapper(f, func(cfile *C.FILE) error {
@@ -364,7 +363,7 @@ func (p *Pigosat) WriteCompactTrace(f io.Writer) error {
 func (p *Pigosat) WriteExtendedTrace(f io.Writer) error {
 	defer p.ready(true)()
 	if Status(C.picosat_res(p.p)) != Unsatisfiable {
-		return errors.New("expected to be in Unsatisfiable state")
+		return fmt.Errorf("expected to be in Unsatisfiable state")
 	}
 
 	return cFileWriterWrapper(f, func(cfile *C.FILE) error {

--- a/pigosat.go
+++ b/pigosat.go
@@ -347,6 +347,36 @@ func (p *Pigosat) WriteClausalCore(f io.Writer) error {
 	})
 }
 
+// Write a compact proof trace in TraceCheck format to a file.
+//
+// Requires that Pigosat was created with EnableTrace == true.
+func (p *Pigosat) WriteCompactTrace(f io.Writer) error {
+	if p.Res() != Unsatisfiable {
+		return errors.New("expected to be in Unsatisfiable state")
+	}
+	defer p.ready(true)()
+	return cFileWriterWrapper(f, func(cfile *C.FILE) error {
+		// void picosat_write_compact_trace (PicoSAT *, FILE * trace_file);
+		_, err := C.picosat_write_compact_trace(p.p, cfile)
+		return err
+	})
+}
+
+// Write an extended proof trace in TraceCheck format to a file.
+//
+// Requires that Pigosat was created with EnableTrace == true.
+func (p *Pigosat) WriteExtendedTrace(f io.Writer) error {
+	if p.Res() != Unsatisfiable {
+		return errors.New("expected to be in Unsatisfiable state")
+	}
+	defer p.ready(true)()
+	return cFileWriterWrapper(f, func(cfile *C.FILE) error {
+		// void picosat_write_extended_trace (PicoSAT *, FILE * trace_file);
+		_, err := C.picosat_write_extended_trace(p.p, cfile)
+		return err
+	})
+}
+
 // A wrapper to take an io.Writer interface and feed it
 // the output from picosat functions that specifically
 // need a *C.FILE

--- a/pigosat.go
+++ b/pigosat.go
@@ -393,6 +393,7 @@ func cFileWriterWrapper(w io.Writer, writeFn func(*C.FILE) error) error {
 	if err != nil {
 		return err
 	}
+	defer wp.Close()
 	defer rp.Close()
 
 	cfile, err := cfdopen(wp, "a")

--- a/pigosat.go
+++ b/pigosat.go
@@ -154,8 +154,9 @@ func New(options *Options) (*Pigosat, error) {
 			C.picosat_measure_all_calls(p)
 		}
 		if options.EnableTrace {
-			if enabled := int(C.picosat_enable_trace_generation(p)); enabled == 0 {
-				return nil, errors.New("trace generation was not enabled in build")
+			if int(C.picosat_enable_trace_generation(p)) == 0 {
+				// The cgo CFLAGS guarantee trace generation using -DTRACE.
+				panic("trace generation was not enabled in build")
 			}
 		}
 	}

--- a/pigosat.go
+++ b/pigosat.go
@@ -373,8 +373,10 @@ func (p *Pigosat) WriteExtendedTrace(f io.Writer) error {
 	})
 }
 
-// A wrapper to take an io.Writer interface and feed it the output from picosat
-// functions that specifically need a *C.FILE
+// cFileWriterWrapper copies writeFn's data into w. writeFn takes a *C.FILE, and
+// whatever writeFn writes to that *C.FILE, cFileWriterWrapper will then
+// copy to w. This wrapper allows the Go API to write to io.Writers anything
+// PicoSAT writes to a *C.FILE. writeFn need not close the *C.FILE.
 func cFileWriterWrapper(w io.Writer, writeFn func(*C.FILE) error) (err error) {
 	rp, wp, err := os.Pipe()
 	if err != nil {

--- a/pigosat.go
+++ b/pigosat.go
@@ -386,11 +386,11 @@ func cFileWriterWrapper(w io.Writer, writeFn func(*C.FILE) error) (err error) {
 		return err
 	}
 	// To avoid double closing wp, close it explicitly at each errror branch.
-	defer func () {
-			if e := rp.Close(); e != nil { // Don't hide prior errors.
-				err = e
-			}
-		}()
+	defer func() {
+		if e := rp.Close(); e != nil { // Don't hide prior errors.
+			err = e
+		}
+	}()
 
 	cfile, err := cfdopen(wp, "a") // wp.Close() below closes cfile.
 	if err != nil {
@@ -428,8 +428,8 @@ func cFileWriterWrapper(w io.Writer, writeFn func(*C.FILE) error) (err error) {
 // This function is only for testing cFileWriterWrapper and is in this file only
 // because Cgo is not supported in test files. See TestCFileWriterWrapper
 // in pigosat_test.go.
-func repeatWriteFn (times int, content byte) (func(*C.FILE) error) {
-	return func (file *C.FILE) error {
+func repeatWriteFn(times int, content byte) func(*C.FILE) error {
+	return func(file *C.FILE) error {
 		for i := 0; i < times; i++ {
 			if _, e := C.fputc(C.int(content), file); e != nil {
 				return e

--- a/pigosat.go
+++ b/pigosat.go
@@ -425,11 +425,15 @@ func cFileWriterWrapper(w io.Writer, writeFn func(*C.FILE) error) (err error) {
 
 // repeatWriteFn returns a writeFn for use with cFileWriterWrapper. The returned
 // writeFn writes the byte in content to the file `times` number of times.
+// If injected is a non-nil error, writeFn returns it instead of writing bytes.
 // This function is only for testing cFileWriterWrapper and is in this file only
 // because Cgo is not supported in test files. See TestCFileWriterWrapper
 // in pigosat_test.go.
-func repeatWriteFn(times int, content byte) func(*C.FILE) error {
+func repeatWriteFn(times int, content byte, injected error) func(*C.FILE) error {
 	return func(file *C.FILE) error {
+		if injected != nil {
+			return injected
+		}
 		for i := 0; i < times; i++ {
 			if _, e := C.fputc(C.int(content), file); e != nil {
 				return e

--- a/pigosat.go
+++ b/pigosat.go
@@ -383,16 +383,13 @@ func cFileWriterWrapper(w io.Writer, writeFn func(*C.FILE) error) (err error) {
 		return err
 	}
 	// Don't hide prior errors if the pipe closes without errors.
-	defer func () {
-			if e := wp.Close(); e != nil {
+	close = func (closer io.Closer) {
+			if e := closer.Close(); e != nil {
 				err = e
 			}
-		}()
-	defer func () {
-			if e := rp.Close(); e != nil {
-				err = e
-			}
-		}()
+		}
+	defer close(wp)
+	defer close(rp)
 
 	cfile, err := cfdopen(wp, "a")
 	if err != nil {

--- a/pigosat.go
+++ b/pigosat.go
@@ -382,6 +382,10 @@ func cFileWriterWrapper(w io.Writer, writeFn func(*C.FILE) error) (err error) {
 		return err
 	}
 	// To avoid double closing wp, close it explicitly at each error branch.
+	// Closing rp here is a data race with the io.Copy(w, rp) call in the
+	// goroutine below, but only if there is an error that causes the the outer
+	// function to return early. But then io.Copy will just return an error,
+	// which we (reasonably) ignore.
 	defer func() {
 		if e := rp.Close(); e != nil { // Don't hide prior errors.
 			err = e

--- a/pigosat.go
+++ b/pigosat.go
@@ -405,3 +405,19 @@ func cFileWriterWrapper(w io.Writer, writeFn func(*C.FILE) error) (err error) {
 	_, err = io.Copy(w, rp)
 	return err
 }
+
+// repeatWriteFn returns a writeFn for use with cFileWriterWrapper. The returned
+// writeFn writes the byte in content to the file `times` number of times.
+// This function is only for testing cFileWriterWrapper and is in this file only
+// because Cgo is not supported in test files. See TestCFileWriterWrapper
+// in pigosat_test.go.
+func repeatWriteFn (times int, content byte) (func(*C.FILE) error) {
+	return func (file *C.FILE) error {
+		for i := 0; i < times; i++ {
+			if _, e := C.fputc(C.int(content), file); e != nil {
+				return e
+			}
+		}
+		return nil
+	}
+}

--- a/pigosat.go
+++ b/pigosat.go
@@ -383,13 +383,13 @@ func cFileWriterWrapper(w io.Writer, writeFn func(*C.FILE) error) (err error) {
 		return err
 	}
 	// Don't hide prior errors if the pipe closes without errors.
-	close = func (closer io.Closer) {
+	closeCloser := func (closer io.Closer) {
 			if e := closer.Close(); e != nil {
 				err = e
 			}
 		}
-	defer close(wp)
-	defer close(rp)
+	defer closeCloser(wp)
+	defer closeCloser(rp)
 
 	cfile, err := cfdopen(wp, "a")
 	if err != nil {

--- a/pigosat.go
+++ b/pigosat.go
@@ -378,25 +378,35 @@ func (p *Pigosat) WriteExtendedTrace(f io.Writer) error {
 // A wrapper to take an io.Writer interface and feed it
 // the output from picosat functions that specifically
 // need a *C.FILE
-func cFileWriterWrapper(w io.Writer, writeFn func(*C.FILE) error) error {
+func cFileWriterWrapper(w io.Writer, writeFn func(*C.FILE) error) (err error) {
+	var wpClosed bool
 	rp, wp, err := os.Pipe()
 	if err != nil {
 		return err
 	}
-	defer wp.Close()
-	defer rp.Close()
+	close := func(f *os.File) {
+		if f != wp || !wpClosed {
+			if closeErr := f.Close(); closeErr != nil && err == nil {
+				err = closeErr
+			}
+		}
+	}
+	defer close(wp)
+	defer close(rp)
 
 	cfile, err := cfdopen(wp, "a")
 	if err != nil {
-		return err
+		return
 	}
-
-	err = writeFn(cfile)
-	C.fflush(cfile)
-	wp.Close()
-	if err != nil {
-		return err
+	if err = writeFn(cfile); err != nil {
+		return
+	}
+	if _, err = C.fflush(cfile); err != nil {
+		return
+	}
+	if err, wpClosed = wp.Close(), true; err != nil {
+		return
 	}
 	_, err = io.Copy(w, rp)
-	return err
+	return
 }

--- a/pigosat.go
+++ b/pigosat.go
@@ -252,15 +252,14 @@ func (p *Pigosat) AddClauses(clauses Formula) {
 }
 
 // Print appends the CNF in DIMACS format to the given file.
-func (p *Pigosat) Print(file *os.File) error {
+// func (p *Pigosat) Print(file *os.File) error {
+func (p *Pigosat) Print(w io.Writer) error {
 	defer p.ready(true)()
-	cfile, err := cfdopen(file, "a")
-	if err != nil {
+	return cFileWriterWrapper(w, func(cfile *C.FILE) error {
+		// void picosat_print (PicoSAT *, FILE *);
+		_, err := C.picosat_print(p.p, cfile)
 		return err
-	}
-	// void picosat_print (PicoSAT *, FILE *);
-	_, err = C.picosat_print(p.p, cfile)
-	return err
+	})
 }
 
 // blocksol adds the inverse of the solution to the clauses.

--- a/pigosat.go
+++ b/pigosat.go
@@ -373,9 +373,8 @@ func (p *Pigosat) WriteExtendedTrace(f io.Writer) error {
 	})
 }
 
-// A wrapper to take an io.Writer interface and feed it
-// the output from picosat functions that specifically
-// need a *C.FILE
+// A wrapper to take an io.Writer interface and feed it the output from picosat
+// functions that specifically need a *C.FILE
 func cFileWriterWrapper(w io.Writer, writeFn func(*C.FILE) error) (err error) {
 	rp, wp, err := os.Pipe()
 	if err != nil {

--- a/pigosat.go
+++ b/pigosat.go
@@ -335,10 +335,13 @@ func (p *Pigosat) BlockSolution(solution Solution) error {
 //
 // Requires that Pigosat was created with EnableTrace == true.
 func (p *Pigosat) WriteClausalCore(f io.Writer) error {
-	if p.Res() != Unsatisfiable {
+	defer p.ready(true)()
+
+	res := Status(C.picosat_res(p.p))
+	if res != Unsatisfiable {
 		return errors.New("expected to be in Unsatisfiable state")
 	}
-	defer p.ready(true)()
+
 	return cFileWriterWrapper(f, func(cfile *C.FILE) error {
 		// void picosat_write_clausal_core (PicoSAT *, FILE * core_file);
 		_, err := C.picosat_write_clausal_core(p.p, cfile)
@@ -350,10 +353,13 @@ func (p *Pigosat) WriteClausalCore(f io.Writer) error {
 //
 // Requires that Pigosat was created with EnableTrace == true.
 func (p *Pigosat) WriteCompactTrace(f io.Writer) error {
-	if p.Res() != Unsatisfiable {
+	defer p.ready(true)()
+
+	res := Status(C.picosat_res(p.p))
+	if res != Unsatisfiable {
 		return errors.New("expected to be in Unsatisfiable state")
 	}
-	defer p.ready(true)()
+
 	return cFileWriterWrapper(f, func(cfile *C.FILE) error {
 		// void picosat_write_compact_trace (PicoSAT *, FILE * trace_file);
 		_, err := C.picosat_write_compact_trace(p.p, cfile)
@@ -365,10 +371,13 @@ func (p *Pigosat) WriteCompactTrace(f io.Writer) error {
 //
 // Requires that Pigosat was created with EnableTrace == true.
 func (p *Pigosat) WriteExtendedTrace(f io.Writer) error {
-	if p.Res() != Unsatisfiable {
+	defer p.ready(true)()
+
+	res := Status(C.picosat_res(p.p))
+	if res != Unsatisfiable {
 		return errors.New("expected to be in Unsatisfiable state")
 	}
-	defer p.ready(true)()
+
 	return cFileWriterWrapper(f, func(cfile *C.FILE) error {
 		// void picosat_write_extended_trace (PicoSAT *, FILE * trace_file);
 		_, err := C.picosat_write_extended_trace(p.p, cfile)

--- a/pigosat.go
+++ b/pigosat.go
@@ -391,18 +391,12 @@ func cFileWriterWrapper(w io.Writer, writeFn func(*C.FILE) error) error {
 		return err
 	}
 
-	errChan := make(chan error)
-	go func() {
-		_, e := io.Copy(w, rp)
-		errChan <- e
-	}()
-
 	err = writeFn(cfile)
 	C.fflush(cfile)
 	wp.Close()
-	copyErr := <-errChan
 	if err != nil {
 		return err
 	}
-	return copyErr
+	_, err = io.Copy(w, rp)
+	return err
 }

--- a/pigosat.go
+++ b/pigosat.go
@@ -400,7 +400,7 @@ func cFileWriterWrapper(w io.Writer, writeFn func(*C.FILE) error) (err error) {
 
 	// We have to read from the pipe in a separate goroutine because the write
 	// end of the pipe will block if the pipe gets full.
-	errChan := make(chan error)
+	errChan := make(chan error, 1)
 	go func() {
 		_, e := io.Copy(w, rp)
 		errChan <- e

--- a/pigosat_test.go
+++ b/pigosat_test.go
@@ -438,9 +438,9 @@ func TestPrint(t *testing.T) {
 	var buf bytes.Buffer
 	for i, ft := range formulaTests {
 		buf.Reset()
-		p, err := New(nil)
+		p, _ := New(nil)
 		p.AddClauses(ft.formula)
-		err = p.Print(&buf)
+		err := p.Print(&buf)
 		if err != nil {
 			t.Errorf("Test %d: Output file not written to: err=%v", i, err)
 		}
@@ -456,15 +456,12 @@ func TestWriteClausalCore(t *testing.T) {
 	prefix := []byte(`p cnf`)
 
 	for i, ft := range formulaTests {
-		p, err := New(&Options{EnableTrace: true})
-		if err != nil {
-			t.SkipNow()
-		}
+		p, _ := New(&Options{EnableTrace: true})
 		p.AddClauses(ft.formula)
 		status, _ := p.Solve()
 
 		buf.Reset()
-		err = p.WriteClausalCore(&buf)
+		err := p.WriteClausalCore(&buf)
 
 		// Only Unsatisfiable solutions should produce
 		// clausal cores
@@ -492,15 +489,12 @@ func TestWriteTrace(t *testing.T) {
 	var buf bytes.Buffer
 
 	for i, ft := range formulaTests {
-		p, err := New(&Options{EnableTrace: true})
-		if err != nil {
-			t.SkipNow()
-		}
+		p, _ := New(&Options{EnableTrace: true})
 		p.AddClauses(ft.formula)
 		status, _ := p.Solve()
 
 		buf.Reset()
-		err = p.WriteCompactTrace(&buf)
+		err := p.WriteCompactTrace(&buf)
 
 		// Only Unsatisfiable solutions should produce a trace
 		if err != nil {

--- a/pigosat_test.go
+++ b/pigosat_test.go
@@ -437,8 +437,9 @@ func TestCFileWriterWrapper(t *testing.T) {
 	// Pick something bigger than pipe buffers usually get. See
 	//   1. http://unix.stackexchange.com/a/11954/17035
 	//   2. http://man7.org/linux/man-pages/man7/pipe.7.html
-	// On Mac OS and Linux, it seems pipes fill up at 65536 bytes.
-	const size int = 1<<16 + 1<<4
+	// On Mac OS and Linux, it seems pipes fill up at 65536 bytes. This is large
+	// enough to  elicit a deadlock in incorrect implementations.
+	const size int = 1<<16 + 1<<15
 	const content byte = 'a'
 	err := cFileWriterWrapper(&buf, repeatWriteFn(size, content))
 	if err != nil {

--- a/pigosat_test.go
+++ b/pigosat_test.go
@@ -65,10 +65,10 @@ func evaluate(formula Formula, solution Solution) bool {
 }
 
 func equalDimacs(d1, d2 string) bool {
-	// We can't rely on the DIMAC output having clauses
-	// in a consistent order. Enabled TRACE when compiling
-	// picosat, for instance, results in a different clause order.
-	// Better to compare the output as a sorted list of lines.
+	// We can't rely on the DIMAC output having clauses in a consistent order.
+	// Enabled TRACE when compiling picosat, for instance, results in a
+	// different clause order. Better to compare the output as a sorted list of
+	// lines.
 	actual := strings.Split(d1, "\n")
 	expected := strings.Split(d2, "\n")
 	sort.Strings(actual)
@@ -463,8 +463,7 @@ func TestWriteClausalCore(t *testing.T) {
 		buf.Reset()
 		err := p.WriteClausalCore(&buf)
 
-		// Only Unsatisfiable solutions should produce
-		// clausal cores
+		// Only Unsatisfiable solutions should producee clausal cores
 		if err != nil {
 			if status == Unsatisfiable {
 				t.Errorf("Test %d: Error calling WriteClausalCore: %v", i, err)
@@ -472,12 +471,11 @@ func TestWriteClausalCore(t *testing.T) {
 			continue
 		}
 
-		// The variable decisions could be different on different
-		// calls, unless each test Formula uses a specific set of
-		// assumptions to force the results.
-		// For now, just make sure the lib writes out a valid dimac
-		// format, which is probably good enough. We are only testing
-		// the API call behavior and not the values.
+		// The variable decisions could be different on different calls, unless
+		// each test Formula uses a specific set of assumptions to force the
+		// results. For now, just make sure the lib writes out a valid dimac
+		// format, which is probably good enough. We are only testing the API
+		// call behavior and not the values.
 		if !bytes.HasPrefix(buf.Bytes(), prefix) {
 			t.Errorf("Test %d: Expected Unsatisfiable clausal core to "+
 				"start with 'p cnf'; got %q", i, buf)

--- a/pigosat_test.go
+++ b/pigosat_test.go
@@ -438,7 +438,7 @@ func TestCFileWriterWrapper(t *testing.T) {
 	//   1. http://unix.stackexchange.com/a/11954/17035
 	//   2. http://man7.org/linux/man-pages/man7/pipe.7.html
 	// On Mac OS and Linux, it seems pipes fill up at 65536 bytes.
-	const size int = 65536 + 1
+	const size int = 1 << 16 + 1<<4
 	const content byte = 'a'
 	err := cFileWriterWrapper(&buf, repeatWriteFn(size, content))
 	if err != nil {

--- a/pigosat_test.go
+++ b/pigosat_test.go
@@ -497,7 +497,7 @@ func TestWriteTrace(t *testing.T) {
 			continue
 		}
 		if buf.Len() == 0 {
-			t.Errorf("Test %d: Expected Unsatisfiable formulat to produce a trace; got 0 bytes", i)
+			t.Errorf("Test %d: Unsatisfiable formula to produced no compact trace", i)
 		}
 
 		buf.Reset()
@@ -511,7 +511,7 @@ func TestWriteTrace(t *testing.T) {
 			continue
 		}
 		if buf.Len() == 0 {
-			t.Errorf("Test %d: Expected Unsatisfiable formulat to produce a trace; got 0 bytes", i)
+			t.Errorf("Test %d: Unsatisfiable formula to produced no extended trace", i)
 		}
 	}
 }

--- a/pigosat_test.go
+++ b/pigosat_test.go
@@ -65,10 +65,8 @@ func evaluate(formula Formula, solution Solution) bool {
 }
 
 func equalDimacs(d1, d2 string) bool {
-	// We can't rely on the DIMAC output having clauses in a consistent order.
-	// Enabled TRACE when compiling picosat, for instance, results in a
-	// different clause order. Better to compare the output as a sorted list of
-	// lines.
+	// We can't rely on the DIMACS output having clauses in a consistent order,
+	// so we compare the output as a sorted list of lines.
 	actual := strings.Split(d1, "\n")
 	expected := strings.Split(d2, "\n")
 	sort.Strings(actual)
@@ -463,7 +461,7 @@ func TestWriteClausalCore(t *testing.T) {
 		buf.Reset()
 		err := p.WriteClausalCore(&buf)
 
-		// Only Unsatisfiable solutions should producee clausal cores
+		// Only Unsatisfiable solutions should produce clausal cores.
 		if err != nil {
 			if status == Unsatisfiable {
 				t.Errorf("Test %d: Error calling WriteClausalCore: %v", i, err)
@@ -471,11 +469,8 @@ func TestWriteClausalCore(t *testing.T) {
 			continue
 		}
 
-		// The variable decisions could be different on different calls, unless
-		// each test Formula uses a specific set of assumptions to force the
-		// results. For now, just make sure the lib writes out a valid dimac
-		// format, which is probably good enough. We are only testing the API
-		// call behavior and not the values.
+		// Just make sure we write out a valid DIMACS format since we are only
+		// testing the API here, not the solutions.
 		if !bytes.HasPrefix(buf.Bytes(), prefix) {
 			t.Errorf("Test %d: Expected Unsatisfiable clausal core to "+
 				"start with 'p cnf'; got %q", i, buf)

--- a/pigosat_test.go
+++ b/pigosat_test.go
@@ -435,28 +435,18 @@ func TestUninitializedOrDeleted(t *testing.T) {
 }
 
 func TestPrint(t *testing.T) {
+	var buf bytes.Buffer
 	for i, ft := range formulaTests {
-		tmp, err := ioutil.TempFile("", "")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer func() {
-			tmp.Close()
-			if err := os.Remove(tmp.Name()); err != nil {
-				t.Error(err)
-			}
-		}()
+		buf.Reset()
 		p, err := New(nil)
 		p.AddClauses(ft.formula)
-		p.Print(tmp)
-		// Now we make sure the file was written.
-		buf, err := ioutil.ReadFile(tmp.Name())
+		err = p.Print(&buf)
 		if err != nil {
 			t.Errorf("Test %d: Output file not written to: err=%v", i, err)
 		}
-		if s := string(buf); s != ft.dimacs {
+		if !equalDimacs(buf.String(), ft.dimacs) {
 			t.Errorf("Test %d: expected >>>\n%s<<< but got >>>\n%s<<<", i,
-				ft.dimacs, s)
+				ft.dimacs, buf.String())
 		}
 	}
 }

--- a/pigosat_test.go
+++ b/pigosat_test.go
@@ -498,6 +498,47 @@ func TestWriteClausalCore(t *testing.T) {
 	}
 }
 
+func TestWriteTrace(t *testing.T) {
+	var buf bytes.Buffer
+
+	for i, ft := range formulaTests {
+		p, err := New(&Options{EnableTrace: true})
+		if err != nil {
+			t.SkipNow()
+		}
+		p.AddClauses(ft.formula)
+		status, _ := p.Solve()
+
+		buf.Reset()
+		err = p.WriteCompactTrace(&buf)
+
+		// Only Unsatisfiable solutions should produce a trace
+		if err != nil {
+			if status == Unsatisfiable {
+				t.Errorf("Test %d: Error calling WriteCompactTrace: %v", i, err)
+			}
+			continue
+		}
+		if buf.Len() == 0 {
+			t.Errorf("Test %d: Expected Unsatisfiable formulat to produce a trace; got 0 bytes", i)
+		}
+
+		buf.Reset()
+		err = p.WriteExtendedTrace(&buf)
+
+		// Only Unsatisfiable solutions should produce a trace
+		if err != nil {
+			if status == Unsatisfiable {
+				t.Errorf("Test %d: Error calling WriteExtendedTrace: %v", i, err)
+			}
+			continue
+		}
+		if buf.Len() == 0 {
+			t.Errorf("Test %d: Expected Unsatisfiable formulat to produce a trace; got 0 bytes", i)
+		}
+	}
+}
+
 // This is the example from the README.
 func Example_readme() {
 	p, _ := New(nil)

--- a/pigosat_test.go
+++ b/pigosat_test.go
@@ -438,7 +438,7 @@ func TestCFileWriterWrapper(t *testing.T) {
 	//   1. http://unix.stackexchange.com/a/11954/17035
 	//   2. http://man7.org/linux/man-pages/man7/pipe.7.html
 	// On Mac OS and Linux, it seems pipes fill up at 65536 bytes.
-	const size int = 1 << 16 + 1<<4
+	const size int = 1<<16 + 1<<4
 	const content byte = 'a'
 	err := cFileWriterWrapper(&buf, repeatWriteFn(size, content))
 	if err != nil {

--- a/pigosat_test.go
+++ b/pigosat_test.go
@@ -432,6 +432,26 @@ func TestUninitializedOrDeleted(t *testing.T) {
 	}
 }
 
+func TestCFileWriterWrapper(t *testing.T) {
+	var buf bytes.Buffer
+	// Pick something bigger than pipe buffers usually get. See
+	//   1. http://unix.stackexchange.com/a/11954/17035
+	//   2. http://man7.org/linux/man-pages/man7/pipe.7.html
+	// On Mac OS and Linux, it seems pipes fill up at 65536 bytes.
+	const size int = 65536 + 1
+	const content byte = 'a'
+	err := cFileWriterWrapper(&buf, repeatWriteFn(size, content))
+	if err != nil {
+		t.Error(err)
+	}
+	if buf.Len() != size {
+		t.Errorf("Only %d of %d bytes written to buffer", buf.Len(), size)
+	}
+	if s := buf.String(); s[0] != content || s[len(s)-1] != content {
+		t.Errorf("Buffer does not contain the expected data")
+	}
+}
+
 func TestPrint(t *testing.T) {
 	var buf bytes.Buffer
 	for i, ft := range formulaTests {


### PR DESCRIPTION
In this pull request I have added:

* WriteClausalCore
* WriteCompactTrace
* WriteExtendedTrace

All 3 of these methods accept `io.Writer`, and will internally feed that to the FILE pointer required by the picosat C API

Additionally, `Print()` has been updated to also accept `io.Writer`. 